### PR TITLE
Fix invalid log collecting

### DIFF
--- a/lib/Plack/Middleware/GitStatus.pm
+++ b/lib/Plack/Middleware/GitStatus.pm
@@ -85,7 +85,7 @@ sub _current_branch {
 sub _last_commit {
     my $self = shift;
 
-    my ($log) = Git::Repository->log('-1');
+    my ($log) = $WORKTREE->log('-1');
     return +{
         commit  => $log->commit,
         author  => $log->author,

--- a/t/01_builder.t
+++ b/t/01_builder.t
@@ -11,7 +11,7 @@ use File::Temp ();
 use File::Which qw(which);
 use Git::Repository;
 
-if (not -x which('git') && not -x "/usr/bin/git" && not -x "/usr/local/bin/git") {
+if (! -x which('git') && ! -x "/usr/bin/git" && ! -x "/usr/local/bin/git") {
     plan skip_all => "git command is necessorry for testing";
 }
 

--- a/t/09_error.t
+++ b/t/09_error.t
@@ -9,7 +9,7 @@ use Plack::Middleware::GitStatus;
 
 use File::Which qw(which);
 
-if (not -x which('git') && not -x "/usr/bin/git" && not -x "/usr/local/bin/git") {
+if (! -x which('git') && ! -x "/usr/bin/git" && ! -x "/usr/local/bin/git") {
     plan skip_all => "git command is necessorry for testing";
 }
 


### PR DESCRIPTION
```
% prove -vb t/01_builder.t
t/01_builder.t .. Use of uninitialized value in sprintf at /home/syohei/.cpanm/work/1374461520.27186/Plack-Middleware-GitStatus-0.02/blib/lib/Plack/Middleware/GitStatus.pm line 71.
Use of uninitialized value in sprintf at /home/syohei/.cpanm/work/1374461520.27186/Plack-Middleware-GitStatus-0.02/blib/lib/Plack/Middleware/GitStatus.pm line 72.
Use of uninitialized value in sprintf at /home/syohei/.cpanm/work/1374461520.27186/Plack-Middleware-GitStatus-0.02/blib/lib/Plack/Middleware/GitStatus.pm line 73.
Use of uninitialized value in sprintf at /home/syohei/.cpanm/work/1374461520.27186/Plack-Middleware-GitStatus-0.02/blib/lib/Plack/Middleware/GitStatus.pm line 74.

    not ok 1

    #   Failed test at t/01_builder.t line 35.
    #                   'fatal: Not a git repository (or any of the parent directories): .git at /home/syohei/perl5/perlbrew/perls/perl-5.16.1/lib/site_perl/5.16.1/Git/Repository/Log/Iterator.pm line 56.
    # '
    #     doesn't match '(?^:CurrentBranch:)'
    not ok 2

    #   Failed test at t/01_builder.t line 36.
    #                   'fatal: Not a git repository (or any of the parent directories): .git at /home/syohei/perl5/perlbrew/perls/perl-5.16.1/lib/site_perl/5.16.1/Git/Repository/Log/Iterator.pm line 56.
    # '
    #     doesn't match '(?^:Commit: [a-z0-9]+)'
    not ok 3

    #   Failed test at t/01_builder.t line 37.
    #                   'fatal: Not a git repository (or any of the parent directories): .git at /home/syohei/perl5/perlbrew/perls/perl-5.16.1/lib/site_perl/5.16.1/Git/Repository/Log/Iterator.pm line 56.
    # '
    #     doesn't match '(?^:Author:)'
    not ok 4

    #   Failed test at t/01_builder.t line 38.
    #                   'fatal: Not a git repository (or any of the parent directories): .git at /home/syohei/perl5/perlbrew/perls/perl-5.16.1/lib/site_perl/5.16.1/Git/Repository/Log/Iterator.pm line 56.
    # '
    #     doesn't match '(?^:Date:)'
    not ok 5

    #   Failed test at t/01_builder.t line 39.
    #                   'fatal: Not a git repository (or any of the parent directories): .git at /home/syohei/perl5/perlbrew/perls/perl-5.16.1/lib/site_perl/5.16.1/Git/Repository/Log/Iterator.pm line 56.
    # '
    #     doesn't match '(?^:Message:)'
    1..5
    # Looks like you failed 5 tests of 5.
not ok 1 - builder

#   Failed test 'builder'
#   at t/01_builder.t line 41.
1..1
# Looks like you failed 1 test of 1.
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/1 subtests 

Test Summary Report
-------------------
t/01_builder.t (Wstat: 256 Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 1
Files=1, Tests=1,  1 wallclock secs ( 0.05 usr  0.00 sys +  0.28 cusr  0.07 csys =  0.40 CPU)
Result: FAIL
```

テストがログが取得できないことで失敗しています。指定した gitリポジトリ
以外(おそらくテストコマンドが実行されるディレクトリ)でログを取得している
ことが原因だと考えられます。

開発環境ではうまくいっていると思うのですが、それは開発ソースが gitで管理されており、
そのリポジトリのログを問題なく取得できたので問題が発生しなかったものと
考えられます。

あとテストの gitがインストールされているかのチェックに不備があったので
修正しました。Perlの演算子の優先順位だと `not`と `&&`では `&&`の方を先に
評価してしまうため, もともとの式だと意図したように動作していませんでした。
`/usr/bin/git`しか gitがないような環境ではテストが skipされてしまいました.
そのため `&&`よりも優先度の高い `!`を使うことで意図した挙動になるように
修正しました.

ご確認のほどよろしくお願いします。
